### PR TITLE
if block for $comments

### DIFF
--- a/src/Controller/CommentController.php
+++ b/src/Controller/CommentController.php
@@ -6,6 +6,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Routing\Annotation\Route;
 use MongoDB\BSON\ObjectId;
+use Psr\Log\LoggerInterface;
 
 use App\Document\Comment;
 use Doctrine\ODM\MongoDB\DocumentManager;
@@ -15,12 +16,13 @@ class CommentController extends AbstractController
     #[Route('/comment/retrieve-comments/{id}', name: 'retrieve_comments')]
     public function retrieveComments(DocumentManager $dm, $id): Response
     {
-        $someId = new ObjectId($id);
 
-        $comments = $dm->getRepository(Comment::class)->findBy(["parent_object_id" => $someId]);
-
-        if (! $comments) {
-            throw $this->createNotFoundException('No comment found for id ' . $id);
+        $comments = [];
+        if ($id === "undefined"){
+            $comments = [];
+            } else {
+            $someId = new ObjectId($id);
+            $comments = $dm->getRepository(Comment::class)->findBy(["parent_object_id" => $someId]);
         }
 
         return new Response(


### PR DESCRIPTION
# Description
- `/comment/retreive-comments/{id}` needs an if block for undefined but does not need exception blocks 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] 
# Screen shots

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Test A: does it work as intended?
  - [x] If `$id` is undefined?
  - [x] If there are no `comments` does it return an empty array?

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

